### PR TITLE
Makes back button easier to tap and more consistent with stock UINavigationBar

### DIFF
--- a/Sources/FancyScrollView/BackButton.swift
+++ b/Sources/FancyScrollView/BackButton.swift
@@ -10,6 +10,9 @@ struct BackButton: View {
         presentationMode.wrappedValue.isPresented ?
             Button(action: { self.presentationMode.wrappedValue.dismiss() }) {
                 Image(systemName: "chevron.left")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: 20, alignment: .leading)
                     .foregroundColor(color)
                     .padding(.horizontal, 16)
                     .background(Rectangle().opacity(0.0))

--- a/Sources/FancyScrollView/BackButton.swift
+++ b/Sources/FancyScrollView/BackButton.swift
@@ -11,7 +11,7 @@ struct BackButton: View {
             Button(action: { self.presentationMode.wrappedValue.dismiss() }) {
                 Image(systemName: "chevron.left")
                     .foregroundColor(color)
-            }
-            .padding(.horizontal, 16) : nil
+                    .padding(.horizontal, 16)
+            } : nil
     }
 }

--- a/Sources/FancyScrollView/BackButton.swift
+++ b/Sources/FancyScrollView/BackButton.swift
@@ -15,7 +15,7 @@ struct BackButton: View {
                     .frame(height: 20, alignment: .leading)
                     .foregroundColor(color)
                     .padding(.horizontal, 16)
-                    .background(Rectangle().opacity(0.0))
+                    // .background(Rectangle().opacity(0.0))
                     .font(Font.body.bold())
             } : nil
     }

--- a/Sources/FancyScrollView/BackButton.swift
+++ b/Sources/FancyScrollView/BackButton.swift
@@ -12,7 +12,8 @@ struct BackButton: View {
                 Image(systemName: "chevron.left")
                     .foregroundColor(color)
                     .padding(.horizontal, 16)
-                    .background(Rectangle().opacity(0.001))
+                    .background(Rectangle().opacity(0.0))
+                    .font(Font.body.bold())
             } : nil
     }
 }

--- a/Sources/FancyScrollView/BackButton.swift
+++ b/Sources/FancyScrollView/BackButton.swift
@@ -12,6 +12,7 @@ struct BackButton: View {
                 Image(systemName: "chevron.left")
                     .foregroundColor(color)
                     .padding(.horizontal, 16)
+                    .background(Rectangle().opacity(0.001))
             } : nil
     }
 }

--- a/Sources/FancyScrollView/BackButton.swift
+++ b/Sources/FancyScrollView/BackButton.swift
@@ -15,7 +15,6 @@ struct BackButton: View {
                     .frame(height: 20, alignment: .leading)
                     .foregroundColor(color)
                     .padding(.horizontal, 16)
-                    // .background(Rectangle().opacity(0.0))
                     .font(Font.body.bold())
             } : nil
     }


### PR DESCRIPTION
In some tests I had a hard time tapping the back button. 
To make this more easy, I've increased the button size and moved the padding inside the button.

With the increased button size and bold SF Symbols font, the icon is now also more consistent with the stock UINavigationBar back button.