### PR TITLE
Fixes swipe to go back behavior

### DIFF
--- a/Sources/FancyScrollView/AppleMusicStyleScrollView.swift
+++ b/Sources/FancyScrollView/AppleMusicStyleScrollView.swift
@@ -17,8 +17,8 @@ struct AppleMusicStyleScrollView: View {
                         }
                         return Text("")
                     }
+                    
                     content
-                        .animation(nil)
                 }
             }
             GeometryReader { geometry in

--- a/Sources/FancyScrollView/BackButton.swift
+++ b/Sources/FancyScrollView/BackButton.swift
@@ -7,15 +7,14 @@ struct BackButton: View {
     var presentationMode: Binding<PresentationMode>
 
     var body: some View {
-        presentationMode.wrappedValue.isPresented ?
-            Button(action: { self.presentationMode.wrappedValue.dismiss() }) {
-                Image(systemName: "chevron.left")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(height: 20, alignment: .leading)
-                    .foregroundColor(color)
-                    .padding(.horizontal, 16)
-                    .font(Font.body.bold())
-            } : nil
+         Button(action: { self.presentationMode.wrappedValue.dismiss() }) {
+             Image(systemName: "chevron.left")
+                 .resizable()
+                 .aspectRatio(contentMode: .fit)
+                 .frame(height: 20, alignment: .leading)
+                 .foregroundColor(color)
+                 .padding(.horizontal, 16)
+                 .font(Font.body.bold())
+         }
     }
 }

--- a/Sources/FancyScrollView/BackButton.swift
+++ b/Sources/FancyScrollView/BackButton.swift
@@ -5,16 +5,23 @@ struct BackButton: View {
 
     @Environment(\.presentationMode)
     var presentationMode: Binding<PresentationMode>
+    
+    @State private var hasBeenShownAtLeastOnce: Bool = false
 
     var body: some View {
-         Button(action: { self.presentationMode.wrappedValue.dismiss() }) {
-             Image(systemName: "chevron.left")
-                 .resizable()
-                 .aspectRatio(contentMode: .fit)
-                 .frame(height: 20, alignment: .leading)
-                 .foregroundColor(color)
-                 .padding(.horizontal, 16)
-                 .font(Font.body.bold())
-         }
+        (presentationMode.wrappedValue.isPresented || hasBeenShownAtLeastOnce) ?
+            Button(action: { self.presentationMode.wrappedValue.dismiss() }) {
+               Image(systemName: "chevron.left")
+                   .resizable()
+                   .aspectRatio(contentMode: .fit)
+                   .frame(height: 20, alignment: .leading)
+                   .foregroundColor(color)
+                   .padding(.horizontal, 16)
+                   .font(Font.body.bold())
+            }
+            .onAppear {
+                self.hasBeenShownAtLeastOnce = true
+            }
+        : nil
     }
 }

--- a/Sources/FancyScrollView/HeaderScrollView.swift
+++ b/Sources/FancyScrollView/HeaderScrollView.swift
@@ -69,6 +69,7 @@ struct HeaderScrollView: View {
         }
         .navigationBarTitle(Text(""), displayMode: .inline)
         .navigationBarHidden(true)
+        .hackNavigationToAllowSwipeBackWhenHidden()
     }
 }
 


### PR DESCRIPTION
> Swipe to go back is reintroduced while keeping the navigation bar hidden.

> Furthermore, this PR fixes a bug where animations were not working for the content of the scroll view.

> Note: I have not tested every combination of having a title or not, header or not, etc. I am not sure whether all behave correctly.