### PR TITLE
fix title and lightMode issue

### DIFF
--- a/Sources/FancyScrollView/BlurView.swift
+++ b/Sources/FancyScrollView/BlurView.swift
@@ -11,7 +11,7 @@ public struct BlurView: UIViewRepresentable {
     public func makeUIView(context: UIViewRepresentableContext<BlurView>) -> UIView {
         let view = UIView(frame: .zero)
         view.backgroundColor = .clear
-        let blurEffect = UIBlurEffect(style: context.environment.colorScheme == .dark ? .dark : .light)
+        let blurEffect = UIBlurEffect(style: .systemThinMaterial)
         let blurView = UIVisualEffectView(effect: blurEffect)
         blurView.translatesAutoresizingMaskIntoConstraints = false
         view.insertSubview(blurView, at: 0)

--- a/Sources/FancyScrollView/HeaderScrollViewTitle.swift
+++ b/Sources/FancyScrollView/HeaderScrollViewTitle.swift
@@ -20,6 +20,7 @@ struct HeaderScrollViewTitle: View {
             }
             .padding(.bottom, 8)
             .opacity(sqrt(largeTitleOpacity))
+            .minimumScaleFactor(0.5)
 
             ZStack {
                 HStack {


### PR DESCRIPTION
Fixed a problem when title is too long, Top blur is  now displayed correctly in light mode

systemThinMaterial automatically checks colorScheme And apply a suitable blur

minimumScaleFactor checks the view size and reduces the size of the text to fit the size.